### PR TITLE
Added graphql language

### DIFF
--- a/client/sidebar.js
+++ b/client/sidebar.js
@@ -20,6 +20,16 @@ const ids = {
 };
 
 /**
+ * Define languages that are not included in highlight.js by default
+ */
+ function defineOtherLanguages() {
+    const graphql = require("highlightjs-graphql")
+    graphql(hljs)
+}
+
+defineOtherLanguages();
+
+/**
  * On document load, try to load languages and themes, try to load the user's
  * preferences if previously set, and assign click handlers to each button.
  */

--- a/client/sidebar.js
+++ b/client/sidebar.js
@@ -22,7 +22,7 @@ const ids = {
 /**
  * Define languages that are not included in highlight.js by default
  */
- function defineOtherLanguages() {
+function defineThirdPartyGrammars() {
     const graphql = require("highlightjs-graphql")
     graphql(hljs)
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "browserify": "16.5.0",
     "clean-css-cli": "4.3.0",
     "highlight.js": "9.16.2",
+    "highlightjs-graphql": "^1.0.2",
     "jquery": "3.4.1",
     "juice": "5.2.0",
     "uglify-es": "3.3.9",


### PR DESCRIPTION
Closes https://github.com/alexwforsythe/code-blocks/issues/171.

Highlight.js does not add new languages anymore, and instead encourages 3rd parties to develop their own packages that they will link to from here [Supported Languages](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md).

From the [official docs](https://highlightjs.readthedocs.io/en/latest/language-contribution.html):

> Sadly, due to lack of maintainer time we no longer merge new languages grammars into the core library. Instead, the project works by encouraging 3rd party language grammar development by willing contributors ready to help and maintain them. 

Therefore, to add support in `code-blocks` for new languages, packages for those languages will have to be explicitly pulled.

In this PR I've defined a  function in which other languages can also be added in the future, add added `graphql` in there.