### PR TITLE
Update broken marketplace link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Installation
 
-Code Blocks is available on the [G Suite Marketplace](https://workspace.google.com/marketplace/app/code_blocks/100740430168).
+Code Blocks is available on the [Google Workspace Marketplace](https://workspace.google.com/marketplace/app/code_blocks/100740430168).
 Select **Install** to begin using it in Google Docs.
 
 ### Starting the add-on


### PR DESCRIPTION
The old link leads to a 404. 

<img width="898" alt="Screenshot 2021-10-24 at 1 19 53 PM" src="https://user-images.githubusercontent.com/12415700/138585360-386e47d1-0aaa-4121-b50e-762525afcde3.png">
