### PR TITLE
Fixed broken link to Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Installation
 
-Code Blocks is available on the [G Suite Marketplace](https://chrome.google.com/webstore/detail/code-blocks/ebieibfdjgmmimpldgengceekpfefmfd).
+Code Blocks is available on the [Google Workspace Marketplace](https://workspace.google.com/marketplace/app/code_blocks/100740430168).
 Select **Install** to begin using it in Google Docs.
 
 ### Starting the add-on
@@ -121,4 +121,4 @@ because they require Google Drive authorization.
 
 ---
 
-[Homepage](https://www.alexwforsythe.com/code-blocks/) | [G Suite Marketplace](https://chrome.google.com/webstore/detail/code-blocks/ebieibfdjgmmimpldgengceekpfefmfd) | [Privacy Policy](https://www.alexwforsythe.com/code-blocks/privacy-policy) | [Terms of Service](https://www.alexwforsythe.com/code-blocks/terms-of-service)
+[Homepage](https://www.alexwforsythe.com/code-blocks/) | [Google Workspace Marketplace](https://workspace.google.com/marketplace/app/code_blocks/100740430168) | [Privacy Policy](https://www.alexwforsythe.com/code-blocks/privacy-policy) | [Terms of Service](https://www.alexwforsythe.com/code-blocks/terms-of-service)


### PR DESCRIPTION
G Suite Marketplace is now the [Google Workspace Marketplace](https://workspace.google.com/marketplace/app/code_blocks/100740430168).

Thanks for the great tool!