### PR TITLE
Updated marketplace link in ToS and Privacy Policy, fixed third item in ToS to use number 3

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -17,4 +17,4 @@ This policy is effective as of 28 October 2019.
 
 ---
 
-[Homepage](https://www.alexwforsythe.com/code-blocks/) | [G Suite Marketplace](https://chrome.google.com/webstore/detail/code-blocks/ebieibfdjgmmimpldgengceekpfefmfd) | [Privacy Policy](https://www.alexwforsythe.com/code-blocks/privacy-policy) | [Terms of Service](https://www.alexwforsythe.com/code-blocks/terms-of-service)
+[Homepage](https://www.alexwforsythe.com/code-blocks/) | [Google Workspace Marketplace](https://workspace.google.com/marketplace/app/code_blocks/100740430168) | [Privacy Policy](https://www.alexwforsythe.com/code-blocks/privacy-policy) | [Terms of Service](https://www.alexwforsythe.com/code-blocks/terms-of-service)

--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -10,7 +10,7 @@ By accessing our app, Code Blocks, you are agreeing to be bound by these terms o
     1. remove any copyright or other proprietary notations from the materials;
 1. This license shall automatically terminate if you violate any of these restrictions and may be terminated by Code Blocks at any time. Upon terminating your viewing of these materials or upon the termination of this license, you must destroy any downloaded materials in your possession whether in electronic or printed format.
 
-## 1. Disclaimer
+## 3. Disclaimer
 
 1. The materials within Code Blocks are provided on an 'as is' basis. Code Blocks makes no warranties, expressed or implied, and hereby disclaims and negates all other warranties including, without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights.
 
@@ -38,4 +38,4 @@ These terms and conditions are governed by and construed in accordance with the 
 
 ---
 
-[Homepage](https://www.alexwforsythe.com/code-blocks/) | [G Suite Marketplace](https://chrome.google.com/webstore/detail/code-blocks/ebieibfdjgmmimpldgengceekpfefmfd) | [Privacy Policy](https://www.alexwforsythe.com/code-blocks/privacy-policy) | [Terms of Service](https://www.alexwforsythe.com/code-blocks/terms-of-service)
+[Homepage](https://www.alexwforsythe.com/code-blocks/) | [Google Workspace Marketplace](https://workspace.google.com/marketplace/app/code_blocks/100740430168) | [Privacy Policy](https://www.alexwforsythe.com/code-blocks/privacy-policy) | [Terms of Service](https://www.alexwforsythe.com/code-blocks/terms-of-service)


### PR DESCRIPTION
I updated the Terms of Service and Privacy Policy files since the G Suite doesn't exist anymore and was replaced with Google Workspace. Also, the third item in the Terms of Service had a number 1 instead of 3, that has been fixed.