### PR TITLE
Upgrade Runtime From Rhino to V8

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -6,5 +6,6 @@
   ],
   "dependencies": {
   },
-  "exceptionLogging": "STACKDRIVER"
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
 }

--- a/client/sidebar.js
+++ b/client/sidebar.js
@@ -27,7 +27,7 @@ function defineThirdPartyGrammars() {
     graphql(hljs)
 }
 
-defineOtherLanguages();
+defineThirdPartyGrammars();
 
 /**
  * On document load, try to load languages and themes, try to load the user's


### PR DESCRIPTION
The solution to the recent deprecation that caused the Code-Blocks to stop working. Ran tests below to resolve the issue.

- [x] Static Code Analysis: Code seems to be plain ES3-ish var-based JavaScript that happens to also be valid V8
- [x] Live Test: Working after fixing reference error that might have been unsuppressed after changing the runtime

Related Issues: #270, #271, #272, #276, #277, #278, #279. #280, #281, #282, #283, #284, #285, #286, #287, #288, #290

## Summary by Sourcery

Update Apps Script configuration file, likely in preparation for migrating the runtime environment, with no meaningful diff content available in this patch.