### PR TITLE
Fix Google Docs add-on after Rhino deprecation

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -4,7 +4,7 @@
     "https://www.googleapis.com/auth/documents.currentonly",
     "https://www.googleapis.com/auth/script.container.ui"
   ],
-  "dependencies": {
-  },
-  "exceptionLogging": "STACKDRIVER"
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
 }

--- a/client/sidebar.js
+++ b/client/sidebar.js
@@ -23,11 +23,11 @@ const ids = {
  * Define languages that are not included in highlight.js by default
  */
 function defineThirdPartyGrammars() {
-    const graphql = require("highlightjs-graphql")
-    graphql(hljs)
+    // const graphql = require("highlightjs-graphql")
+    // graphql(hljs)
 }
 
-defineOtherLanguages();
+// defineOtherLanguages();
 
 /**
  * On document load, try to load languages and themes, try to load the user's


### PR DESCRIPTION
## Summary

This PR fixes the add-on after Google's removal of the Rhino runtime.

### Changes

- Add `"runtimeVersion": "V8"` to `appsscript.json`
- Disable GraphQL language registration which currently causes the sidebar initialization to fail
- Remove the call to `defineOtherLanguages()` which is referenced but not defined anywhere in the repository

### Symptoms before this fix

- Only the "Help" menu item appears in Google Docs
- "Start" is missing
- The sidebar fails to initialize
- Browser console reports:
  - `The Rhino runtime is deprecated and no longer supported`
  - `ReferenceError: defineOtherLanguages is not defined`

### Testing

Tested in Google Docs using a test deployment created from Apps Script.

Verified:
- "Start" menu appears again
- Sidebar opens successfully
- Code formatting works

## Summary by Sourcery

Update the Google Docs add-on to work with the V8 runtime and prevent sidebar initialization failures.

Bug Fixes:
- Prevent sidebar initialization errors caused by undefined GraphQL language registration and missing defineOtherLanguages().

Enhancements:
- Disable optional GraphQL syntax highlighting to avoid runtime issues under the new V8 environment.

Build:
- Configure the Apps Script project to use the V8 runtime in appsscript.json.